### PR TITLE
removed RequireLoadedStores requirement. This override is included in…

### DIFF
--- a/sencha-workspace/SlateAdmin/app/Application.js
+++ b/sencha-workspace/SlateAdmin/app/Application.js
@@ -7,9 +7,6 @@ Ext.define('SlateAdmin.Application', {
     requires: [
         'SlateAdmin.API',
 
-        // Jarvus enhancements
-        'Jarvus.ext.override.data.RequireLoadedStores',
-
         // framework features
         'Ext.state.LocalStorageProvider'
     ],


### PR DESCRIPTION
… the ext-5.1.1.451 branch of the jarvus-lazydata package and does not need to be referenced here. ref issue #2