### PR TITLE
Release: slate-admin v2.1.6

### DIFF
--- a/sencha-workspace/SlateAdmin/app/model/progress/narratives/Report.js
+++ b/sencha-workspace/SlateAdmin/app/model/progress/narratives/Report.js
@@ -89,6 +89,8 @@ Ext.define('SlateAdmin.model.progress.narratives.Report', {
     ],
     proxy: {
         type: 'slaterecords',
-        url: '/progress/narratives/reports'
+        url: '/progress/narratives/reports',
+        limitParam: null,
+        startParam: null
     }
 });


### PR DESCRIPTION
- Fixes issue where loading narrative reports for a given section was limited to the first 25