### PR TITLE
Release: slate-admin v2.1.13

### DIFF
--- a/sencha-workspace/SlateAdmin/app/controller/progress/Interims.js
+++ b/sencha-workspace/SlateAdmin/app/controller/progress/Interims.js
@@ -22,7 +22,7 @@ Ext.define('SlateAdmin.controller.progress.Interims', {
 
             xtype: 'progress-interims-manager'
         },
-        myClassesToggleBtn: 'progress-interims-sectionsgrid button[action=myClassesToggle]',
+        myClassesOnlyCheckbox: 'progress-interims-sectionsgrid checkboxfield[name=myClassesOnly]',
         termSelector: 'progress-interims-sectionsgrid #termSelector',
         sectionsGrid: 'progress-interims-sectionsgrid',
         studentsGrid: 'progress-interims-studentsgrid',
@@ -41,8 +41,8 @@ Ext.define('SlateAdmin.controller.progress.Interims', {
             activate: 'onManagerActivate'
         },
 
-        myClassesToggleBtn: {
-            toggle: 'onMyClassesToggle'
+        myClassesOnlyCheckbox: {
+            change: 'onMyClassesOnlyCheckboxChange'
         },
         termSelector: {
             change: 'onTermChange'
@@ -115,7 +115,7 @@ Ext.define('SlateAdmin.controller.progress.Interims', {
         this.syncSections();
     },
 
-    onMyClassesToggle: function () {
+    onMyClassesOnlyCheckboxChange: function () {
         this.syncSections();
     },
 
@@ -368,7 +368,7 @@ Ext.define('SlateAdmin.controller.progress.Interims', {
             sectionsStore = me.getProgressInterimsSectionsStore(),
             sectionsProxy = sectionsStore.getProxy(),
             managerCt = me.getManagerCt(),
-            myClassesToggleBtn = me.getMyClassesToggleBtn(),
+            myClassesOnlyCheckbox = me.getMyClassesOnlyCheckbox(),
             termSelector = me.getTermSelector(),
             termsStore = termSelector.getStore(),
             term = termSelector.getValue();
@@ -399,7 +399,7 @@ Ext.define('SlateAdmin.controller.progress.Interims', {
             return; // setting the term will call this function again via the change event
         }
 
-        sectionsProxy.setExtraParam('enrolled_user', myClassesToggleBtn.pressed ? 'current' : '');
+        sectionsProxy.setExtraParam('enrolled_user', myClassesOnlyCheckbox.getValue() ? 'current' : '');
         sectionsProxy.setExtraParam('term', term);
         sectionsStore.loadIfDirty();
     },

--- a/sencha-workspace/SlateAdmin/app/controller/progress/Interims.js
+++ b/sencha-workspace/SlateAdmin/app/controller/progress/Interims.js
@@ -234,6 +234,8 @@ Ext.define('SlateAdmin.controller.progress.Interims', {
             student.set('report', report, { dirty: false });
         }
 
+        me.fireEvent('beforereportload', report);
+
         editorForm.enable();
         editorForm.setScrollY(0, true);
         editorForm.loadRecord(report);

--- a/sencha-workspace/SlateAdmin/app/view/progress/NavPanel.js
+++ b/sencha-workspace/SlateAdmin/app/view/progress/NavPanel.js
@@ -16,10 +16,10 @@ Ext.define('SlateAdmin.view.progress.NavPanel', {
                 text: 'Section Interim Reports',
                 href: '#progress/interims',
                 children: [
-                    {
-                        text: 'Search & Print',
-                        href: '#progress/interims/print'
-                    }
+                    // {
+                    //     text: 'Search & Print',
+                    //     href: '#progress/interims/print'
+                    // }
                     // {
                     //     text: 'Email',
                     //     href: '#progress/interims/email'
@@ -30,10 +30,10 @@ Ext.define('SlateAdmin.view.progress.NavPanel', {
                 text: 'Section Term Reports',
                 href: '#progress/narratives',
                 children: [
-                    {
-                        text: 'Search & Print',
-                        href: '#progress/narratives/print'
-                    }
+                    // {
+                    //     text: 'Search & Print',
+                    //     href: '#progress/narratives/print'
+                    // }
                     // {
                     //     text: 'Email',
                     //     href: '#progress/narratives/email'

--- a/sencha-workspace/SlateAdmin/app/view/progress/interims/SectionsGrid.js
+++ b/sencha-workspace/SlateAdmin/app/view/progress/interims/SectionsGrid.js
@@ -4,34 +4,45 @@ Ext.define('SlateAdmin.view.progress.interims.SectionsGrid', {
     requires: [
         'Ext.grid.column.Template',
         'Ext.toolbar.Spacer',
-        'Ext.button.Button'
+        'Ext.form.field.ComboBox',
+        'Ext.form.field.Checkbox'
     ],
 
 
     width: 250,
     store: 'progress.interims.Sections',
     componentCls: 'progress-interims-grid',
-    tbar: [
+    dockedItems: [
         {
-            xtype: 'button',
-            text: 'My classes only',
-            action: 'myClassesToggle',
-            enableToggle: true
+            dock: 'top',
+
+            xtype: 'toolbar',
+            items: [
+                {
+                    itemId: 'termSelector',
+                    flex: 1,
+
+                    xtype: 'combobox',
+
+                    queryMode: 'local',
+                    store: 'Terms',
+                    valueField: 'Handle',
+                    displayField: 'Title',
+                    forceSelection: true
+                }
+            ]
         },
         {
-            xtype: 'tbspacer'
-        },
-        {
-            itemId: 'termSelector',
-            flex: 1,
+            dock: 'top',
 
-            xtype: 'combobox',
-
-            queryMode: 'local',
-            store: 'Terms',
-            valueField: 'Handle',
-            displayField: 'Title',
-            forceSelection: true
+            xtype: 'toolbar',
+            items: [
+                {
+                    xtype: 'checkboxfield',
+                    boxLabel: 'Show only my classes',
+                    name: 'myClassesOnly'
+                }
+            ]
         }
     ],
     columns: [{


### PR DESCRIPTION
- Change interims "my classes only" toggle button to check box
- Split interims term selector and "my classes only" check box to separate lines
- Temporarily hide search&print navigation links for narratives and interims
- Add `beforereportload` event for interims