### PR TITLE
Release: slate-admin v2.1.27

### DIFF
--- a/sencha-workspace/SlateAdmin/app/controller/people/Contacts.js
+++ b/sencha-workspace/SlateAdmin/app/controller/people/Contacts.js
@@ -381,23 +381,13 @@ Ext.define('SlateAdmin.controller.people.Contacts', {
             fieldName = context.field,
             record = context.record,
             editor = context.column.getEditor(record),
-            activeEditor = editingPlugin.getActiveEditor(),
             labelEditor, valueEditor, labelStore, templateRecord, valueField, placeholder;
 
-        // allow editing multiple contact points
-        if (activeEditor && activeEditor != editor) {
-            Ext.defer(function() {
-                activeEditor.ignoreNoChange = false;
-                activeEditor.editing = true;
-                activeEditor.completeEdit();
-            }, 50);
-            return false;
-        }
         // get both components
         if (fieldName == 'Label') {
             labelEditor = editor;
             valueEditor = cm.getHeaderById('value').getEditor(record);
-        } else if(fieldName == 'String') {
+        } else if (fieldName == 'String') {
             if (record.phantom && !record.get('Label')) {
                 return false;
             }

--- a/sencha-workspace/SlateAdmin/app/controller/people/Invite.js
+++ b/sencha-workspace/SlateAdmin/app/controller/people/Invite.js
@@ -126,7 +126,7 @@ Ext.define('SlateAdmin.controller.people.Invite', {
 
 
         for (; i < selectedPeopleLength; i++) {
-            people.push(selectedPeople[0].get('Person').getId());
+            people.push(selectedPeople[i].get('Person').getId());
         }
 
         if (!people.length) {

--- a/sencha-workspace/SlateAdmin/app/controller/people/Invite.js
+++ b/sencha-workspace/SlateAdmin/app/controller/people/Invite.js
@@ -30,9 +30,11 @@ Ext.define('SlateAdmin.controller.people.Invite', {
             click: 'onOpenClick'
         },
         'people-invitationspanel grid checkcolumn': {
-            headerclick: 'onGridCheckHeaderClick'
+            headerclick: 'onGridCheckHeaderClick',
+            beforecheckchange: 'onGridBeforeCheckChange'
         },
         'people-invitationspanel grid': {
+            beforeselect: 'onGridBeforeSelect',
             select: 'onGridSelect'
         },
         'people-invitationspanel button[action=cancel]': {
@@ -56,7 +58,7 @@ Ext.define('SlateAdmin.controller.people.Invite', {
         // TODO: add all results if no selection made
         store.removeAll();
         store.add(Ext.Array.map(selectedPeople, function(person) {
-            return { Person: person, selected: true };
+            return { Person: person, selected: Boolean(person.get('PrimaryEmail')) };
         }));
 
         window.show();
@@ -71,6 +73,22 @@ Ext.define('SlateAdmin.controller.people.Invite', {
             invitation.commit();
         });
         store.resumeEvents();
+    },
+
+    onGridBeforeCheckChange: function(column, rowIndex, checked) {
+        if (!this.getPeopleInvitationsStore().getAt(rowIndex).get('Email')) {
+            return false;
+        }
+
+        return true;
+    },
+
+    onGridBeforeSelect: function(rowModel, invitation) {
+        if (!invitation.get('Email')) {
+            return false;
+        }
+
+        return true;
     },
 
     onGridSelect: function(rowModel, invitation) {

--- a/sencha-workspace/SlateAdmin/app/controller/progress/interims/Email.js
+++ b/sencha-workspace/SlateAdmin/app/controller/progress/interims/Email.js
@@ -165,7 +165,7 @@ Ext.define('SlateAdmin.controller.progress.interims.Email', {
                     sendEmailsBtn.enable();
 
                     if (!success || !data.success) {
-                        Ext.Msg.confirm('Failed to send emails', 'A problem occurred while sending emails, all or some may not have been sent');
+                        Ext.Msg.alert('Failed to send emails', 'A problem occurred while sending emails, all or some may not have been sent');
                         return;
                     }
 

--- a/sencha-workspace/SlateAdmin/app/controller/progress/terms/Email.js
+++ b/sencha-workspace/SlateAdmin/app/controller/progress/terms/Email.js
@@ -165,7 +165,7 @@ Ext.define('SlateAdmin.controller.progress.terms.Email', {
                     sendEmailsBtn.enable();
 
                     if (!success || !data.success) {
-                        Ext.Msg.confirm('Failed to send emails', 'A problem occurred while sending emails, all or some may not have been sent');
+                        Ext.Msg.alert('Failed to send emails', 'A problem occurred while sending emails, all or some may not have been sent');
                         return;
                     }
 

--- a/sencha-workspace/SlateAdmin/app/view/people/invitations/Panel.js
+++ b/sencha-workspace/SlateAdmin/app/view/people/invitations/Panel.js
@@ -35,7 +35,10 @@ Ext.define('SlateAdmin.view.people.invitations.Panel', {
         columnLines: true,
 //      multiSelect: true,
         viewConfig: {
-            markDirty: false
+            markDirty: false,
+            getRowClass: function(person) {
+                return person.get('Email') ? '' : 'x-item-disabled';
+            }
         },
         columns: {
             defaults: {
@@ -58,7 +61,8 @@ Ext.define('SlateAdmin.view.people.invitations.Panel', {
             },{
                 text: 'Email Address',
                 flex: 2,
-                dataIndex: 'Email'
+                dataIndex: 'Email',
+                emptyCellText: '<em>Add email to invite</em>'
             },{
                 text: 'Account Status',
                 flex: 2,
@@ -79,8 +83,8 @@ Ext.define('SlateAdmin.view.people.invitations.Panel', {
                             cls = 'student-nologin';
                         }
                     } else {
-                        text = Person.get('AccountLevel');
-                        cls = Person.get('AccountLevel').toLowerCase();
+                        text = Person.get('AccountLevel') || 'Contact';
+                        cls = text.toLowerCase();
 
                         if (!Person.get('Username')) {
                             text += ', no login';


### PR DESCRIPTION
- Remove unneeded code
- Show alert modals instead of confirm modals for errors
- Prevent selection of ineligible invitation recipients
- Fix bug where first invitation recipient would receive [# of selected recipients] invitations instead of each selection receiving one