### PR TITLE
Release: slate-admin v2.2.6

### DIFF
--- a/sencha-workspace/SlateAdmin/app/controller/progress/interims/Report.js
+++ b/sencha-workspace/SlateAdmin/app/controller/progress/interims/Report.js
@@ -571,7 +571,7 @@ Ext.define('SlateAdmin.controller.progress.interims.Report', {
 
         for (; i < studentsLength; i++) {
             student = studentsStore.getAt(i);
-            report = reportsStore.query('StudentID', student.getId()).first();
+            report = reportsStore.getAt(reportsStore.findExact('StudentID', student.getId()));
 
             student.beginEdit();
             student.set('report', report || null, { dirty: false });

--- a/sencha-workspace/SlateAdmin/app/controller/progress/terms/Report.js
+++ b/sencha-workspace/SlateAdmin/app/controller/progress/terms/Report.js
@@ -572,7 +572,7 @@ Ext.define('SlateAdmin.controller.progress.terms.Report', {
 
         for (; i < studentsLength; i++) {
             student = studentsStore.getAt(i);
-            report = reportsStore.query('StudentID', student.getId()).first();
+            report = reportsStore.getAt(reportsStore.findExact('StudentID', student.getId()));
 
             student.beginEdit();
             student.set('report', report || null, { dirty: false });

--- a/sencha-workspace/SlateAdmin/app/view/courses/NavPanel.js
+++ b/sencha-workspace/SlateAdmin/app/view/courses/NavPanel.js
@@ -24,7 +24,7 @@ Ext.define('SlateAdmin.view.courses.NavPanel', {
         }]
     },{
         dock: 'bottom',
-        
+
         xtype: 'container',
         layout: 'fit',
         padding: 10,
@@ -45,7 +45,10 @@ Ext.define('SlateAdmin.view.courses.NavPanel', {
         labelSeparator: '',
         labelAlign: 'right',
         labelPad: 10,
-        autoSelect: false // only for combo boxes
+
+        // only for combo boxes:
+        autoSelect: false,
+        matchFieldWidth: false
     },
     items: [{
         xtype: 'combo',

--- a/sencha-workspace/SlateAdmin/app/view/people/AdvancedSearchForm.js
+++ b/sencha-workspace/SlateAdmin/app/view/people/AdvancedSearchForm.js
@@ -74,6 +74,7 @@ Ext.define('SlateAdmin.view.people.AdvancedSearchForm', {
             fieldLabel: 'Advisor',
             displayField: 'FullName',
             valueField: 'Username',
+            matchFieldWidth: false,
             emptyText: 'Any',
             queryMode: 'local',
             store: {
@@ -105,6 +106,7 @@ Ext.define('SlateAdmin.view.people.AdvancedSearchForm', {
             fieldLabel: 'Ward Advisor',
             displayField: 'FullName',
             valueField: 'Username',
+            matchFieldWidth: false,
             emptyText: 'Any',
             queryMode: 'local',
             store: {


### PR DESCRIPTION
- Allow combo selectors to match content width
- Ensure strict matching for reports