### PR TITLE
Release: slate-admin v2.3.1

### DIFF
--- a/sencha-workspace/SlateAdmin/app/controller/progress/interims/Print.js
+++ b/sencha-workspace/SlateAdmin/app/controller/progress/interims/Print.js
@@ -185,13 +185,20 @@ Ext.define('SlateAdmin.controller.progress.interims.Print', {
     },
 
     loadPrintout: function(callback) {
-        var printoutCmp = this.getPrintoutCmp();
+        var printoutCmp = this.getPrintoutCmp(),
+            url = this.buildHtmlUrl();
+
+        // skip load if URL is the same
+        if (printoutCmp.iframeEl.dom.src === url) {
+            Ext.callback(callback, null, [printoutCmp]);
+            return;
+        }
 
         if (callback) {
             printoutCmp.on('previewload', callback, null, { single: true });
         }
 
         printoutCmp.setLoading('Loading printout&hellip;');
-        printoutCmp.iframeEl.dom.src = this.buildHtmlUrl();
+        printoutCmp.iframeEl.dom.src = url;
     }
 });

--- a/sencha-workspace/SlateAdmin/app/controller/progress/interims/Print.js
+++ b/sencha-workspace/SlateAdmin/app/controller/progress/interims/Print.js
@@ -105,7 +105,17 @@ Ext.define('SlateAdmin.controller.progress.interims.Print', {
 
     onPrintPrintoutClick: function() {
         this.loadPrintout(function(previewCmp) {
-            previewCmp.iframeEl.dom.contentWindow.print();
+            try {
+                previewCmp.iframeEl.dom.contentWindow.print();
+            } catch (err) {
+                Ext.Msg.alert(
+                    'Printing unavailable',
+                    [
+                        '<p>Your browser\'s print function could not be triggered automatically.</p>',
+                        '<p>Try using the <strong>Open in Browser Tab</strong> button instead and printing manually</p>'
+                    ].join('')
+                );
+            }
         });
     },
 

--- a/sencha-workspace/SlateAdmin/app/controller/progress/interims/Print.js
+++ b/sencha-workspace/SlateAdmin/app/controller/progress/interims/Print.js
@@ -54,6 +54,9 @@ Ext.define('SlateAdmin.controller.progress.interims.Print', {
         'progress-interims-print-container button[action=print-printout]': {
             click: 'onPrintPrintoutClick'
         },
+        'progress-interims-print-container button[action=open-tab]': {
+            click: 'onOpenTabClick'
+        },
         'progress-interims-print-container button[action=save-csv]': {
             click: 'onSaveCsvClick'
         },
@@ -104,6 +107,10 @@ Ext.define('SlateAdmin.controller.progress.interims.Print', {
         this.loadPrintout(function(previewCmp) {
             previewCmp.iframeEl.dom.contentWindow.print();
         });
+    },
+
+    onOpenTabClick: function() {
+        window.open(this.buildHtmlUrl());
     },
 
     onSaveCsvClick: function() {
@@ -173,6 +180,10 @@ Ext.define('SlateAdmin.controller.progress.interims.Print', {
         return filters;
     },
 
+    buildHtmlUrl: function() {
+        return Slate.API.buildUrl('/progress/section-interim-reports?'+Ext.Object.toQueryString(this.buildFilters()));
+    },
+
     loadPrintout: function(callback) {
         var printoutCmp = this.getPrintoutCmp();
 
@@ -181,6 +192,6 @@ Ext.define('SlateAdmin.controller.progress.interims.Print', {
         }
 
         printoutCmp.setLoading('Loading printout&hellip;');
-        printoutCmp.iframeEl.dom.src = Slate.API.buildUrl('/progress/section-interim-reports?'+Ext.Object.toQueryString(this.buildFilters()));
+        printoutCmp.iframeEl.dom.src = this.buildHtmlUrl();
     }
 });

--- a/sencha-workspace/SlateAdmin/app/controller/progress/terms/Print.js
+++ b/sencha-workspace/SlateAdmin/app/controller/progress/terms/Print.js
@@ -185,13 +185,20 @@ Ext.define('SlateAdmin.controller.progress.terms.Print', {
     },
 
     loadPrintout: function(callback) {
-        var printoutCmp = this.getPrintoutCmp();
+        var printoutCmp = this.getPrintoutCmp(),
+            url = this.buildHtmlUrl();
+
+        // skip load if URL is the same
+        if (printoutCmp.iframeEl.dom.src === url) {
+            Ext.callback(callback, null, [printoutCmp]);
+            return;
+        }
 
         if (callback) {
             printoutCmp.on('previewload', callback, null, { single: true });
         }
 
         printoutCmp.setLoading('Loading printout&hellip;');
-        printoutCmp.iframeEl.dom.src = this.buildHtmlUrl();
+        printoutCmp.iframeEl.dom.src = url;
     }
 });

--- a/sencha-workspace/SlateAdmin/app/controller/progress/terms/Print.js
+++ b/sencha-workspace/SlateAdmin/app/controller/progress/terms/Print.js
@@ -54,6 +54,9 @@ Ext.define('SlateAdmin.controller.progress.terms.Print', {
         'progress-terms-print-container button[action=print-printout]': {
             click: 'onPrintPrintoutClick'
         },
+        'progress-terms-print-container button[action=open-tab]': {
+            click: 'onOpenTabClick'
+        },
         'progress-terms-print-container button[action=save-csv]': {
             click: 'onSaveCsvClick'
         },
@@ -104,6 +107,10 @@ Ext.define('SlateAdmin.controller.progress.terms.Print', {
         this.loadPrintout(function(previewCmp) {
             previewCmp.iframeEl.dom.contentWindow.print();
         });
+    },
+
+    onOpenTabClick: function() {
+        window.open(this.buildHtmlUrl());
     },
 
     onSaveCsvClick: function() {
@@ -173,6 +180,10 @@ Ext.define('SlateAdmin.controller.progress.terms.Print', {
         return filters;
     },
 
+    buildHtmlUrl: function() {
+        return Slate.API.buildUrl('/progress/section-term-reports?'+Ext.Object.toQueryString(this.buildFilters()));
+    },
+
     loadPrintout: function(callback) {
         var printoutCmp = this.getPrintoutCmp();
 
@@ -181,6 +192,6 @@ Ext.define('SlateAdmin.controller.progress.terms.Print', {
         }
 
         printoutCmp.setLoading('Loading printout&hellip;');
-        printoutCmp.iframeEl.dom.src = Slate.API.buildUrl('/progress/section-term-reports?'+Ext.Object.toQueryString(this.buildFilters()));
+        printoutCmp.iframeEl.dom.src = this.buildHtmlUrl();
     }
 });

--- a/sencha-workspace/SlateAdmin/app/controller/progress/terms/Print.js
+++ b/sencha-workspace/SlateAdmin/app/controller/progress/terms/Print.js
@@ -105,7 +105,17 @@ Ext.define('SlateAdmin.controller.progress.terms.Print', {
 
     onPrintPrintoutClick: function() {
         this.loadPrintout(function(previewCmp) {
-            previewCmp.iframeEl.dom.contentWindow.print();
+            try {
+                previewCmp.iframeEl.dom.contentWindow.print();
+            } catch (err) {
+                Ext.Msg.alert(
+                    'Printing unavailable',
+                    [
+                        '<p>Your browser\'s print function could not be triggered automatically.</p>',
+                        '<p>Try using the <strong>Open in Browser Tab</strong> button instead and printing manually</p>'
+                    ].join('')
+                );
+            }
         });
     },
 

--- a/sencha-workspace/SlateAdmin/app/store/TermsTree.js
+++ b/sencha-workspace/SlateAdmin/app/store/TermsTree.js
@@ -29,7 +29,11 @@ Ext.define('SlateAdmin.store.TermsTree', {
                 _finishExpand();
             } else {
                 node.set('loading', true);
-                termsStore.load(function(records) {
+                termsStore.load(function(records, operation, success) {
+                    if (!success) {
+                        return;
+                    }
+
                     me.loadFromArray(records);
                     node.set('loading', false);
                     _finishExpand();

--- a/sencha-workspace/SlateAdmin/app/store/people/GroupsTree.js
+++ b/sencha-workspace/SlateAdmin/app/store/people/GroupsTree.js
@@ -54,7 +54,11 @@ Ext.define('SlateAdmin.store.people.GroupsTree', {
                 _finishExpand();
             } else {
                 node.set('loading', true);
-                groupsStore.load(function(records) {
+                groupsStore.load(function(records, operation, success) {
+                    if (!success) {
+                        return;
+                    }
+
                     me.loadFromArray(records);
                     node.set('loading', false);
                     _finishExpand();

--- a/sencha-workspace/SlateAdmin/app/view/LinksNavPanel.js
+++ b/sencha-workspace/SlateAdmin/app/view/LinksNavPanel.js
@@ -1,4 +1,3 @@
-/*jslint browser: true, undef: true *//*global Ext*/
 Ext.define('SlateAdmin.view.LinksNavPanel', {
     extend: 'Ext.Panel',
     xtype: 'links-navpanel',
@@ -9,12 +8,19 @@ Ext.define('SlateAdmin.view.LinksNavPanel', {
 
     tpl: [
         '<ul class="slate-nav-list">',
-            '<tpl for=".">',
-                '<li class="slate-nav-list-item"><a class="slate-nav-list-link <tpl if="selected">selected</tpl>" href="{href}">{text}</a></li>',
-                '<tpl for="children">',
-                    '<li class="slate-nav-list-item"><a class="slate-nav-list-link <tpl if="selected">selected</tpl>" href="{href}">↳ {text}</a></li>',
-                '</tpl>',
-            '</tpl>',
+        '    <tpl for=".">',
+
+        '        <li class="slate-nav-list-item">',
+        '            <a class="slate-nav-list-link <tpl if="selected">selected</tpl>" href="{href}">{text}</a>',
+        '        </li>',
+
+        '        <tpl for="children">',
+        '            <li class="slate-nav-list-item">',
+        '                <a class="slate-nav-list-link <tpl if="selected">selected</tpl>" href="{href}">↳ {text}</a>',
+        '            </li>',
+        '        </tpl>',
+
+        '    </tpl>',
         '</ul>'
     ],
 

--- a/sencha-workspace/SlateAdmin/app/view/progress/interims/print/Container.js
+++ b/sencha-workspace/SlateAdmin/app/view/progress/interims/print/Container.js
@@ -91,7 +91,7 @@ Ext.define('SlateAdmin.view.progress.interims.print.Container', {
                 { xtype: 'tbfill' },
                 {
                     xtype: 'button',
-                    text: 'Load Report Printout',
+                    text: 'Preview Printout',
                     action: 'load-printout'
                 },
                 {

--- a/sencha-workspace/SlateAdmin/app/view/progress/interims/print/Container.js
+++ b/sencha-workspace/SlateAdmin/app/view/progress/interims/print/Container.js
@@ -99,6 +99,11 @@ Ext.define('SlateAdmin.view.progress.interims.print.Container', {
                     text: 'Print via Browser',
                     action: 'print-printout'
                 },
+                {
+                    xtype: 'button',
+                    text: 'Open to Browser Tab',
+                    action: 'open-tab'
+                },
                 // {
                 //     xtype: 'button',
                 //     text: 'Print to PDF',

--- a/sencha-workspace/SlateAdmin/app/view/progress/terms/SectionsGrid.js
+++ b/sencha-workspace/SlateAdmin/app/view/progress/terms/SectionsGrid.js
@@ -2,7 +2,6 @@ Ext.define('SlateAdmin.view.progress.terms.SectionsGrid', {
     extend: 'Ext.grid.Panel',
     xtype: 'progress-terms-sectionsgrid',
     requires: [
-        'Ext.grid.column.Template',
         'Ext.form.field.ComboBox',
         'Ext.form.field.Checkbox'
     ],

--- a/sencha-workspace/SlateAdmin/app/view/progress/terms/print/Container.js
+++ b/sencha-workspace/SlateAdmin/app/view/progress/terms/print/Container.js
@@ -99,6 +99,11 @@ Ext.define('SlateAdmin.view.progress.terms.print.Container', {
                     text: 'Print via Browser',
                     action: 'print-printout'
                 },
+                {
+                    xtype: 'button',
+                    text: 'Open to Browser Tab',
+                    action: 'open-tab'
+                },
                 // {
                 //     xtype: 'button',
                 //     text: 'Print to PDF',

--- a/sencha-workspace/SlateAdmin/app/view/progress/terms/print/Container.js
+++ b/sencha-workspace/SlateAdmin/app/view/progress/terms/print/Container.js
@@ -91,7 +91,7 @@ Ext.define('SlateAdmin.view.progress.terms.print.Container', {
                 { xtype: 'tbfill' },
                 {
                     xtype: 'button',
-                    text: 'Load Report Printout',
+                    text: 'Preview Printout',
                     action: 'load-printout'
                 },
                 {


### PR DESCRIPTION
- Prevent errors that can occur when certain load calls fail
- Add distinctive style to currently selected navigation menu item
- Add "Open to Browser Tab" buttons for report printers
- Prevent loading reports twice when requesting to print already-loaded query
- Detect and report on print failures