### PR TITLE
Release: slate-admin v2.3.3

### DIFF
--- a/sencha-workspace/SlateAdmin/app/controller/progress/interims/Print.js
+++ b/sencha-workspace/SlateAdmin/app/controller/progress/interims/Print.js
@@ -182,16 +182,30 @@ Ext.define('SlateAdmin.controller.progress.interims.Print', {
 
 
     // controller methods
-    buildFilters: function() {
-        var filters = this.getOptionsForm().getValues();
+    buildReportParams: function() {
+        var formValues = this.getOptionsForm().getValues(),
+            params = {},
+            paramKey, paramValue;
 
-        filters.status = 'published';
+        for (paramKey in formValues) {
+            if (
+                formValues.hasOwnProperty(paramKey)
+                && (paramValue = formValues[paramKey])
+                && (paramKey != 'status' || paramValue != 'any')
+            ) {
+                if (paramKey == 'group') {
+                    paramKey = 'students';
+                    paramValue = 'group>'+paramValue;
+                }
+                params[paramKey] = paramValue;
+            }
+        }
 
-        return filters;
+        return params;
     },
 
     buildHtmlUrl: function() {
-        return Slate.API.buildUrl('/progress/section-interim-reports?'+Ext.Object.toQueryString(this.buildFilters()));
+        return Slate.API.buildUrl('/progress/section-interim-reports?'+Ext.Object.toQueryString(this.buildReportParams()));
     },
 
     loadPrintout: function(callback) {

--- a/sencha-workspace/SlateAdmin/app/controller/progress/terms/Print.js
+++ b/sencha-workspace/SlateAdmin/app/controller/progress/terms/Print.js
@@ -183,11 +183,25 @@ Ext.define('SlateAdmin.controller.progress.terms.Print', {
 
     // controller methods
     buildReportParams: function() {
-        var filters = this.getOptionsForm().getValues();
+        var formValues = this.getOptionsForm().getValues(),
+            params = {},
+            paramKey, paramValue;
 
-        filters.status = 'published';
+        for (paramKey in formValues) {
+            if (
+                formValues.hasOwnProperty(paramKey)
+                && (paramValue = formValues[paramKey])
+                && (paramKey != 'status' || paramValue != 'any')
+            ) {
+                if (paramKey == 'group') {
+                    paramKey = 'students';
+                    paramValue = 'group>'+paramValue;
+                }
+                params[paramKey] = paramValue;
+            }
+        }
 
-        return filters;
+        return params;
     },
 
     buildHtmlUrl: function() {

--- a/sencha-workspace/SlateAdmin/app/view/progress/interims/print/Container.js
+++ b/sencha-workspace/SlateAdmin/app/view/progress/interims/print/Container.js
@@ -36,7 +36,11 @@ Ext.define('SlateAdmin.view.progress.interims.print.Container', {
                         labelWidth: 60,
                         forceSelection: true,
                         allowBlank: true,
-                        valueField: 'ID'
+                        typeAhead: false,
+                        queryMode: 'local',
+                        emptyText: 'Any',
+                        matchFieldWidth: false,
+                        anyMatch: true
                     },
                     items: [
                         {
@@ -46,43 +50,47 @@ Ext.define('SlateAdmin.view.progress.interims.print.Container', {
 
                             store: 'Terms',
                             displayField: 'Title',
-                            valueField: 'Handle',
-
-                            queryMode: 'local',
-                            forceSelection: false
+                            valueField: 'Handle'
                         },
                         {
                             name: 'advisor',
                             fieldLabel: 'Advisor',
-                            emptyText: 'Any',
 
                             store: 'Advisors',
                             displayField: 'SortName',
-                            valueField: 'Username',
-
-                            queryMode: 'local',
-                            typeAhead: true,
-                            forceSelection: false
+                            valueField: 'Username'
                         },
                         {
                             name: 'author',
                             fieldLabel: 'Author',
-                            emptyText: 'Any',
 
                             store: 'progress.interims.Authors',
                             displayField: 'SortName',
-                            valueField: 'Username',
-
-                            queryMode: 'local',
-                            typeAhead: true,
-                            forceSelection: false
+                            valueField: 'Username'
                         },
                         {
                             xtype: 'slate-personfield',
                             name: 'student',
                             fieldLabel: 'Student',
-                            emptyText: 'All',
-                            appendQuery: 'class:student'
+                            appendQuery: 'class:student',
+                            queryMode: 'remote'
+                        },
+                        {
+                            name: 'group',
+                            fieldLabel: 'Group',
+
+                            store: 'people.Groups',
+                            displayField: 'namesPath',
+                            valueField: 'Handle'
+                        },
+                        {
+                            name: 'status',
+                            fieldLabel: 'Status',
+
+                            store: ['published', 'draft', 'any'],
+                            value: 'published',
+
+                            editable: false
                         }
                     ]
                 }

--- a/sencha-workspace/SlateAdmin/app/view/progress/terms/print/Container.js
+++ b/sencha-workspace/SlateAdmin/app/view/progress/terms/print/Container.js
@@ -39,7 +39,11 @@ Ext.define('SlateAdmin.view.progress.terms.print.Container', {
                         labelWidth: 60,
                         forceSelection: true,
                         allowBlank: true,
-                        valueField: 'ID'
+                        typeAhead: false,
+                        queryMode: 'local',
+                        emptyText: 'Any',
+                        matchFieldWidth: false,
+                        anyMatch: true
                     },
                     items: [
                         {
@@ -49,43 +53,47 @@ Ext.define('SlateAdmin.view.progress.terms.print.Container', {
 
                             store: 'Terms',
                             displayField: 'Title',
-                            valueField: 'Handle',
-
-                            queryMode: 'local',
-                            forceSelection: false
+                            valueField: 'Handle'
                         },
                         {
                             name: 'advisor',
                             fieldLabel: 'Advisor',
-                            emptyText: 'Any',
 
                             store: 'Advisors',
                             displayField: 'SortName',
-                            valueField: 'Username',
-
-                            queryMode: 'local',
-                            typeAhead: true,
-                            forceSelection: false
+                            valueField: 'Username'
                         },
                         {
                             name: 'author',
                             fieldLabel: 'Author',
-                            emptyText: 'Any',
 
                             store: 'progress.terms.Authors',
                             displayField: 'SortName',
-                            valueField: 'Username',
-
-                            queryMode: 'local',
-                            typeAhead: true,
-                            forceSelection: false
+                            valueField: 'Username'
                         },
                         {
                             xtype: 'slate-personfield',
                             name: 'student',
                             fieldLabel: 'Student',
-                            emptyText: 'All',
-                            appendQuery: 'class:student'
+                            appendQuery: 'class:student',
+                            queryMode: 'remote'
+                        },
+                        {
+                            name: 'group',
+                            fieldLabel: 'Group',
+
+                            store: 'people.Groups',
+                            displayField: 'namesPath',
+                            valueField: 'Handle'
+                        },
+                        {
+                            name: 'status',
+                            fieldLabel: 'Status',
+
+                            store: ['published', 'draft', 'any'],
+                            value: 'published',
+
+                            editable: false
                         }
                     ]
                 },


### PR DESCRIPTION
- Fix need to click combo fields twice on first load
- Add group and status filters for term/interim reports printer
- Improve filters UI for term/interims reports printer