### PR TITLE
Release: slate-admin v2.4.3

### DIFF
--- a/sencha-workspace/SlateAdmin/app/Application.js
+++ b/sencha-workspace/SlateAdmin/app/Application.js
@@ -41,6 +41,7 @@ Ext.define('SlateAdmin.Application', {
         'settings.Courses',
         'settings.Departments',
         'settings.Terms',
+        'settings.GlobalRecipients',
 
         'Terms',
         'Locations',

--- a/sencha-workspace/SlateAdmin/app/controller/people/Profile.js
+++ b/sencha-workspace/SlateAdmin/app/controller/people/Profile.js
@@ -104,7 +104,11 @@ Ext.define('SlateAdmin.controller.people.Profile', {
         me.getMasqueradeBtnCt().setVisible(siteUserIsAdmin && person.get('Username'));
 
         profilePanel.setLoading('Loading&hellip;');
-        Ext.StoreMgr.requireLoaded(['people.Classes', 'people.Groups'], function() {
+        Ext.StoreMgr.requireLoaded([
+            'people.Classes',
+            'people.Groups',
+            'people.AccountLevels'
+        ], function() {
             profileForm.loadRecord(person);
             profilePanel.setLoading(false);
             me.syncButtons();

--- a/sencha-workspace/SlateAdmin/app/controller/people/Profile.js
+++ b/sencha-workspace/SlateAdmin/app/controller/people/Profile.js
@@ -21,7 +21,8 @@ Ext.define('SlateAdmin.controller.people.Profile', {
 
     stores: [
         'people.Classes',
-        'people.Groups'
+        'people.Groups',
+        'people.Advisors@Slate.store',
     ],
 
     refs: {
@@ -107,7 +108,8 @@ Ext.define('SlateAdmin.controller.people.Profile', {
         Ext.StoreMgr.requireLoaded([
             'people.Classes',
             'people.Groups',
-            'people.AccountLevels'
+            'people.AccountLevels',
+            'people.Advisors'
         ], function() {
             profileForm.loadRecord(person);
             profilePanel.setLoading(false);

--- a/sencha-workspace/SlateAdmin/app/controller/progress/interims/Email.js
+++ b/sencha-workspace/SlateAdmin/app/controller/progress/interims/Email.js
@@ -21,7 +21,7 @@ Ext.define('SlateAdmin.controller.progress.interims.Email', {
 
     stores: [
         'Terms',
-        'Advisors@Slate.store.people',
+        'people.Advisors@Slate.store',
         'progress.interims.Authors',
         'progress.interims.Emails'
     ],

--- a/sencha-workspace/SlateAdmin/app/controller/progress/interims/Print.js
+++ b/sencha-workspace/SlateAdmin/app/controller/progress/interims/Print.js
@@ -23,7 +23,7 @@ Ext.define('SlateAdmin.controller.progress.interims.Print', {
 
     stores: [
         'Terms',
-        'Advisors@Slate.store.people',
+        'people.Advisors@Slate.store',
         'progress.interims.Authors'
     ],
 

--- a/sencha-workspace/SlateAdmin/app/controller/progress/terms/Email.js
+++ b/sencha-workspace/SlateAdmin/app/controller/progress/terms/Email.js
@@ -21,7 +21,7 @@ Ext.define('SlateAdmin.controller.progress.terms.Email', {
 
     stores: [
         'Terms',
-        'Advisors@Slate.store.people',
+        'people.Advisors@Slate.store',
         'progress.terms.Authors',
         'progress.terms.Emails'
     ],

--- a/sencha-workspace/SlateAdmin/app/controller/progress/terms/Print.js
+++ b/sencha-workspace/SlateAdmin/app/controller/progress/terms/Print.js
@@ -23,7 +23,7 @@ Ext.define('SlateAdmin.controller.progress.terms.Print', {
 
     stores: [
         'Terms',
-        'Advisors@Slate.store.people',
+        'people.Advisors@Slate.store',
         'progress.terms.Authors'
     ],
 

--- a/sencha-workspace/SlateAdmin/app/controller/settings/GlobalRecipients.js
+++ b/sencha-workspace/SlateAdmin/app/controller/settings/GlobalRecipients.js
@@ -1,0 +1,130 @@
+Ext.define('SlateAdmin.controller.settings.GlobalRecipients', {
+    extend: 'Ext.app.Controller',
+
+    // controller config
+    views: [
+        'settings.globalrecipients.Manager'
+    ],
+
+    stores: [
+        'people.GlobalRecipients@Slate.store'
+    ],
+
+    models: [
+        'person.GlobalRecipient@Slate.model'
+    ],
+
+    routes: {
+        'settings/global-recipients': 'showManager'
+    },
+
+    refs: {
+        settingsNavPanel: 'settings-navpanel',
+
+        manager: {
+            selector: 'globalrecipients-manager',
+            autoCreate: true,
+
+            xtype: 'globalrecipients-manager'
+        }
+    },
+
+
+    control: {
+        'globalrecipients-manager': {
+            show: 'onManagerShow',
+            beforeedit: 'onCellEditorBeforeEdit',
+            edit: 'onCellEditorEdit',
+            viewclick: 'onViewClick',
+            deleteclick: 'onDeleteClick'
+        },
+        'globalrecipients-manager button[action=create]': {
+            click: 'onCreateClick'
+        }
+    },
+
+
+    // route handlers
+    showManager: function() {
+        var me = this,
+            navPanel = me.getSettingsNavPanel();
+
+        Ext.suspendLayouts();
+
+        Ext.util.History.suspendState();
+        navPanel.setActiveLink('settings/global-recipients');
+        navPanel.expand();
+        Ext.util.History.resumeState(false); // false to discard any changes to state
+
+        me.application.getController('Viewport').loadCard(me.getManager());
+
+        Ext.resumeLayouts(true);
+    },
+
+
+    // event handlers
+    onManagerShow: function(managerPanel) {
+        var store = this.getPeopleGlobalRecipientsStore();
+
+        if (!store.isLoaded()) {
+            managerPanel.setLoading('Loading global recipients&hellip;');
+            store.load({
+                callback: function() {
+                    managerPanel.setLoading(false);
+                }
+            });
+        }
+
+        Ext.util.History.pushState('settings/global-recipients', 'Global Recipients &mdash; Settings');
+    },
+
+    onCreateClick: function() {
+        var me = this,
+            globalRecipient = me.getPeopleGlobalRecipientsStore().insert(0, {})[0];
+
+        this.getManager().getPlugin('cellediting').startEdit(globalRecipient, 0);
+    },
+
+    onCellEditorBeforeEdit: function(editor, context) {
+        if (context.field != 'PersonID') {
+            return;
+        }
+
+        // pre-load combo store with selected person
+        var personData = context.record.get('Person');
+        if (personData) {
+            context.column.getEditor().getStore().loadRawData([personData]);
+        }
+    },
+
+    onCellEditorEdit: function(editor, e) {
+        var record = e.record;
+
+        if (record.isValid()) {
+            record.save();
+        }
+    },
+
+    onViewClick: function(grid, record) {
+        var personData = record.get('Person'),
+            personId = record.get('PersonID'),
+            username;
+
+        if (!personData && !personId) {
+            Ext.Msg.alert('Cannot view profile', 'No person is currently selected');
+            return;
+        }
+
+        Ext.util.History.pushState(['people', 'lookup', personData.Username || '?id=' + (personData.ID || personId), 'profile']);
+    },
+
+    onDeleteClick: function(grid, record) {
+        grid.setSelection(record);
+
+        Ext.Msg.confirm('Deleting Global Recipient', 'Are you sure you want to delete this global recipient?', function(btn) {
+            if (btn == 'yes') {
+                record.erase();
+            }
+        });
+    }
+});

--- a/sencha-workspace/SlateAdmin/app/view/people/details/Profile.js
+++ b/sencha-workspace/SlateAdmin/app/view/people/details/Profile.js
@@ -160,6 +160,21 @@ Ext.define('SlateAdmin.view.people.details.Profile', {
                 minValue: 1990,
                 hidden: true
             },{
+                xtype: 'combo',
+                name: 'AdvisorID',
+                fieldLabel: 'Advisor',
+                hidden: true,
+
+                store: 'people.Advisors',
+                displayField: 'SortName',
+                valueField: 'ID',
+                forceSelection: true,
+                typeAhead: false,
+                queryMode: 'local',
+                emptyText: 'Select',
+                matchFieldWidth: false,
+                anyMatch: true
+            },{
                 xtype: 'tagfield',
                 name: 'groupIDs',
                 fieldLabel: 'Groups',

--- a/sencha-workspace/SlateAdmin/app/view/progress/interims/email/Container.js
+++ b/sencha-workspace/SlateAdmin/app/view/progress/interims/email/Container.js
@@ -58,7 +58,7 @@ Ext.define('SlateAdmin.view.progress.interims.email.Container', {
                             name: 'advisor',
                             fieldLabel: 'Advisor',
 
-                            store: 'Advisors',
+                            store: 'people.Advisors',
                             displayField: 'SortName',
                             valueField: 'Username'
                         },

--- a/sencha-workspace/SlateAdmin/app/view/progress/interims/print/Container.js
+++ b/sencha-workspace/SlateAdmin/app/view/progress/interims/print/Container.js
@@ -56,7 +56,7 @@ Ext.define('SlateAdmin.view.progress.interims.print.Container', {
                             name: 'advisor',
                             fieldLabel: 'Advisor',
 
-                            store: 'Advisors',
+                            store: 'people.Advisors',
                             displayField: 'SortName',
                             valueField: 'Username'
                         },

--- a/sencha-workspace/SlateAdmin/app/view/progress/terms/email/Container.js
+++ b/sencha-workspace/SlateAdmin/app/view/progress/terms/email/Container.js
@@ -58,7 +58,7 @@ Ext.define('SlateAdmin.view.progress.terms.email.Container', {
                             name: 'advisor',
                             fieldLabel: 'Advisor',
 
-                            store: 'Advisors',
+                            store: 'people.Advisors',
                             displayField: 'SortName',
                             valueField: 'Username'
                         },

--- a/sencha-workspace/SlateAdmin/app/view/progress/terms/print/Container.js
+++ b/sencha-workspace/SlateAdmin/app/view/progress/terms/print/Container.js
@@ -59,7 +59,7 @@ Ext.define('SlateAdmin.view.progress.terms.print.Container', {
                             name: 'advisor',
                             fieldLabel: 'Advisor',
 
-                            store: 'Advisors',
+                            store: 'people.Advisors',
                             displayField: 'SortName',
                             valueField: 'Username'
                         },

--- a/sencha-workspace/SlateAdmin/app/view/settings/NavPanel.js
+++ b/sencha-workspace/SlateAdmin/app/view/settings/NavPanel.js
@@ -8,7 +8,8 @@ Ext.define('SlateAdmin.view.settings.NavPanel', {
         { href: '#settings/groups', text: 'Groups' },
         { href: '#settings/terms', text: 'Terms' },
         { href: '#settings/departments', text: 'Departments' },
-        { href: '#settings/courses', text: 'Courses' }
+        { href: '#settings/courses', text: 'Courses' },
+        { href: '#settings/global-recipients', text: 'Global Recipients' }
 //        { href: '#settings/locations', text: 'Locations' },
 //        { href: '#settings/asset-statuses', text: 'Asset Statuses' }
     ]

--- a/sencha-workspace/SlateAdmin/app/view/settings/globalrecipients/Manager.js
+++ b/sencha-workspace/SlateAdmin/app/view/settings/globalrecipients/Manager.js
@@ -1,0 +1,65 @@
+Ext.define('SlateAdmin.view.settings.globalrecipients.Manager', {
+    extend: 'Ext.grid.Panel',
+    xtype: 'globalrecipients-manager',
+    requires: [
+        'SlateAdmin.widget.field.Person',
+        'Ext.grid.plugin.CellEditing'
+    ],
+
+    store: 'people.GlobalRecipients',
+
+    columns: [{
+        text: 'Title',
+        flex: 2,
+        dataIndex: 'Title',
+        editor: {
+            xtype: 'textfield'
+        }
+    },{
+        xtype:'templatecolumn',
+        text: 'Person',
+        flex: 1,
+        dataIndex: 'PersonID',
+        tpl: '<tpl for="Person">{FirstName} {LastName}</tpl>',
+        getSortParam: function() {
+            return 'Person';
+        },
+        editor: {
+            xtype: 'slate-personfield',
+            valueField: 'ID',
+            listeners: {
+                select: function(comboField) {
+                    comboField.up('editor').completeEdit();
+                }
+            }
+        }
+    },{
+        xtype: 'actioncolumn',
+        dataIndex: 'Class',
+        width: 80,
+        items: [
+            {
+                action: 'view',
+                glyph: 0xf06e, // fa-eye // 0xf0ca, // fa-list-ul
+                tooltip: 'View Profile'
+            },
+            {
+                action: 'delete',
+                iconCls: 'glyph-danger',
+                glyph: 0xf056, // fa-minus-circle
+                tooltip: 'Delete Global Recipient'
+            }
+        ]
+    }],
+    bbar: [{
+        xtype: 'button',
+        glyph: 0xf055, // fa-plus-circle,
+        cls: 'glyph-success',
+        text: 'Create Global Recipient',
+        action: 'create'
+    }],
+    plugins: [{
+        pluginId: 'cellediting',
+        ptype: 'cellediting'
+    }]
+});


### PR DESCRIPTION
- feat: add profile field for editing advisor
- feat: add settings section for global recipients
- fix: case where first profile opened would appear as needing to be saved before being edited